### PR TITLE
PLATML-4570 split

### DIFF
--- a/recipes/python/retail/Dockerfile
+++ b/recipes/python/retail/Dockerfile
@@ -23,13 +23,6 @@ COPY . .
 
 RUN python setup.py clean --all install
 
-#INSTALL modules needed by application
-RUN /usr/bin/python3.5 -m pip install -U numpy
-RUN /usr/bin/python3.5 -m pip install -U pandas
-RUN /usr/bin/python3.5 -m pip install -U sklearn
-RUN /usr/bin/python3.5 -m pip install -U scipy
-RUN /usr/bin/python3.5 -m pip install -U fastparquet
-
 RUN cp dist/retail*.egg /application.egg
 
 ENV PYTHONPATH=$PYTHONPATH:/application.egg

--- a/recipes/python/retail/Dockerfile
+++ b/recipes/python/retail/Dockerfile
@@ -15,7 +15,13 @@
 # from Adobe.
 #####################################################################
 
-FROM adobe/acp-dsw-ml-runtime-python:0.24.2
+FROM adobe/acp-dsw-ml-runtime-python:0.26.2
+
+WORKDIR /root/retail
+
+COPY . .
+
+RUN python setup.py clean --all install
 
 #INSTALL modules needed by application
 RUN /usr/bin/python3.5 -m pip install -U numpy
@@ -24,7 +30,6 @@ RUN /usr/bin/python3.5 -m pip install -U sklearn
 RUN /usr/bin/python3.5 -m pip install -U scipy
 RUN /usr/bin/python3.5 -m pip install -U fastparquet
 
-COPY dist/retail*.egg /application.egg
+RUN cp dist/retail*.egg /application.egg
 
 ENV PYTHONPATH=$PYTHONPATH:/application.egg
-

--- a/recipes/python/retail/build.sh
+++ b/recipes/python/retail/build.sh
@@ -15,13 +15,6 @@
 # from Adobe.
 #####################################################################
 
-#Build sample python app
-echo "Building .egg binary for project"
-sudo python setup.py clean --all install
-
-echo ""
-echo ""
-
 echo "Please enter the version number for your recipe's docker image"
 read version
 

--- a/recipes/python/retail/retail.config.json
+++ b/recipes/python/retail/retail.config.json
@@ -29,18 +29,6 @@
       {
         "key": "ACP_DSW_TRAINING_XDM_SCHEMA",
         "value": "/_customer/default/DSWRetailSales"
-      },
-      {
-        "key": "evaluation.labelColumn",
-        "value": "weeklySalesAhead"
-      },
-      {
-        "key": "evaluation.trainRatio",
-        "value": "0.8"
-      },
-      {
-        "key": "evaluation.metrics",
-        "value": "MAPE,MAE,RMSE,MASE"
       }
   	]
   },

--- a/recipes/python/retail/retail/evaluator.py
+++ b/recipes/python/retail/retail/evaluator.py
@@ -49,3 +49,18 @@ class Evaluator(RegressionEvaluator):
         test = dataframe[test_start:]
 
         return train, test
+
+    def evaluate(self, data=[], model={}, configProperties={}):
+        print ("Evaluation evaluate triggered")
+        test = data.drop('weeklySalesAhead', axis=1)
+        y_pred = model.predict(test)
+        y_actual = data['weeklySalesAhead'].values
+        mape = np.mean(np.abs((y_actual - y_pred) / y_actual))
+        mae = np.mean(np.abs(y_actual - y_pred))
+        rmse = np.sqrt(np.mean((y_actual - y_pred) ** 2))
+
+        metric = [{"name": "MAPE", "value": mape, "valueType": "double"},
+                  {"name": "MAE", "value": mae, "valueType": "double"},
+                  {"name": "RMSE", "value": rmse, "valueType": "double"}]
+
+        return metric

--- a/recipes/python/retail/retail/evaluator.py
+++ b/recipes/python/retail/retail/evaluator.py
@@ -14,13 +14,13 @@
 # is strictly forbidden unless prior written permission is obtained
 # from Adobe.
 #####################################################################
-from ml.runtime.python.core.RegressionEvaluator import RegressionEvaluator
+from ml.runtime.python.Interfaces.AbstractEvaluator import AbstractEvaluator
 from data_access_sdk_python.reader import DataSetReader
 from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 
-class Evaluator(RegressionEvaluator):
+class Evaluator(AbstractEvaluator):
     def __init__(self):
        print ("Initiate")
 

--- a/recipes/python/retail/retail/evaluator.py
+++ b/recipes/python/retail/retail/evaluator.py
@@ -44,16 +44,16 @@ class Evaluator(AbstractEvaluator):
         # Split
         train_start = '2010-02-12'
         train_end = '2012-01-27'
-        test_start = '2012-02-03'
+        val_start = '2012-02-03'
         train = dataframe[train_start:train_end]
-        test = dataframe[test_start:]
+        val = dataframe[val_start:]
 
-        return train, test
+        return train, val
 
     def evaluate(self, data=[], model={}, configProperties={}):
         print ("Evaluation evaluate triggered")
-        test = data.drop('weeklySalesAhead', axis=1)
-        y_pred = model.predict(test)
+        val = data.drop('weeklySalesAhead', axis=1)
+        y_pred = model.predict(val)
         y_actual = data['weeklySalesAhead'].values
         mape = np.mean(np.abs((y_actual - y_pred) / y_actual))
         mae = np.mean(np.abs(y_actual - y_pred))

--- a/recipes/python/retail/retail/evaluator.py
+++ b/recipes/python/retail/retail/evaluator.py
@@ -16,7 +16,6 @@
 #####################################################################
 from ml.runtime.python.Interfaces.AbstractEvaluator import AbstractEvaluator
 from data_access_sdk_python.reader import DataSetReader
-from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 
@@ -25,23 +24,6 @@ class Evaluator(AbstractEvaluator):
        print ("Initiate")
 
     def split(self, configProperties={}, dataframe=None):
-
-        dataframe.date = pd.to_datetime(dataframe.date)
-        dataframe['week'] = dataframe.date.dt.week
-        dataframe['year'] = dataframe.date.dt.year
-
-        dataframe = pd.concat([dataframe, pd.get_dummies(dataframe['storeType'])], axis=1)
-        dataframe.drop('storeType', axis=1, inplace=True)
-        dataframe['isHoliday'] = dataframe['isHoliday'].astype(int)
-
-        dataframe['weeklySalesAhead'] = dataframe.shift(-45)['weeklySales']
-        dataframe['weeklySalesLag'] = dataframe.shift(45)['weeklySales']
-        dataframe['weeklySalesDiff'] = (dataframe['weeklySales'] - dataframe['weeklySalesLag']) / dataframe['weeklySalesLag']
-        dataframe.dropna(0, inplace=True)
-
-        dataframe = dataframe.set_index(dataframe.date)
-        dataframe.drop('date', axis=1, inplace=True)
-        # Split
         train_start = '2010-02-12'
         train_end = '2012-01-27'
         val_start = '2012-02-03'

--- a/recipes/python/retail/retail/scoringdataloader.py
+++ b/recipes/python/retail/retail/scoringdataloader.py
@@ -31,15 +31,14 @@ def load(configProperties):
                                user_token=configProperties['ML_FRAMEWORK_IMS_TOKEN'],
                                service_token=configProperties['ML_FRAMEWORK_IMS_ML_TOKEN'])
 
-    scoring_data_set_id = configProperties.get("scoringDataSetId")
     timeframe = configProperties.get("timeframe")
 
     if (timeframe is not None):
         date_before = datetime.utcnow().date()
         date_after = date_before - timedelta(minutes=int(timeframe))
-        df = prodreader.load(data_set_id=scoring_data_set_id, ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'], date_after=date_after, date_before=date_before)
+        df = prodreader.load(data_set_id=configProperties['scoringDataSetId'], ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'], date_after=date_after, date_before=date_before)
     else:
-        df = prodreader.load(data_set_id=scoring_data_set_id, ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'])
+        df = prodreader.load(data_set_id=configProperties['scoringDataSetId'], ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'])
 
     #########################################
     # Data Preparation/Feature Engineering

--- a/recipes/python/retail/retail/trainingdataloader.py
+++ b/recipes/python/retail/retail/trainingdataloader.py
@@ -43,5 +43,21 @@ def load(configProperties):
         dataframe = prodreader.load(data_set_id=configProperties['trainingDataSetId'],
                              ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'])
 
+    dataframe.date = pd.to_datetime(dataframe.date)
+    dataframe['week'] = dataframe.date.dt.week
+    dataframe['year'] = dataframe.date.dt.year
+
+    dataframe = pd.concat([dataframe, pd.get_dummies(dataframe['storeType'])], axis=1)
+    dataframe.drop('storeType', axis=1, inplace=True)
+    dataframe['isHoliday'] = dataframe['isHoliday'].astype(int)
+
+    dataframe['weeklySalesAhead'] = dataframe.shift(-45)['weeklySales']
+    dataframe['weeklySalesLag'] = dataframe.shift(45)['weeklySales']
+    dataframe['weeklySalesDiff'] = (dataframe['weeklySales'] - dataframe['weeklySalesLag']) / dataframe['weeklySalesLag']
+    dataframe.dropna(0, inplace=True)
+
+    dataframe = dataframe.set_index(dataframe.date)
+    dataframe.drop('date', axis=1, inplace=True)
+
     print("Training Data Load Finish")
     return dataframe

--- a/recipes/python/retail/retail/trainingdataloader.py
+++ b/recipes/python/retail/retail/trainingdataloader.py
@@ -32,20 +32,16 @@ def load(configProperties):
                                user_token=configProperties['ML_FRAMEWORK_IMS_TOKEN'],
                                service_token=configProperties['ML_FRAMEWORK_IMS_ML_TOKEN'])
 
-    training_data_set_id = configProperties.get("trainingDataSetId")
     timeframe = configProperties.get("timeframe")
 
     if (timeframe is not None):
         date_before = datetime.utcnow().date()
         date_after = date_before - timedelta(minutes=int(timeframe))
-        dataframe = prodreader.load(data_set_id=training_data_set_id, ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'],
+        dataframe = prodreader.load(data_set_id=configProperties['trainingDataSetId'], ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'],
                              date_after=date_after, date_before=date_before)
     else:
-        dataframe = prodreader.load(data_set_id=training_data_set_id,
+        dataframe = prodreader.load(data_set_id=configProperties['trainingDataSetId'],
                              ims_org=configProperties['ML_FRAMEWORK_IMS_TENANT_ID'])
 
-    evaluator = Evaluator()
-    (train_data, _) = evaluator.split(configProperties, dataframe)
-
     print("Training Data Load Finish")
-    return train_data
+    return dataframe


### PR DESCRIPTION
- Because of split change in runtime, trainingdataloader should now just return the whole dataframe. and split in evluator.py shoould take in a dataframe/config and return 2 split datasets
- Made change in build.sh and the dockerfile so that the setup.py step occurs in the container so that the recipe egg has python version 3.5. This is more consistent with tensorflow recipes and this is a safer option since setup.py on the user's machine may generate an egg for a different python version while the runtime egg would still have python version 3.5, which could lead to errors.
- Go back to using AbstractEvaluator defined by the user instead of RegressionEvaluator. In my opinion this example should be for the AbstractEvaluator since it is a more general use case. And the RegressionEvaluator and it's necessary configs seem to cause more confusion 