### PR TITLE
PLATML 4623 - updated sample to support default regression evaluator

### DIFF
--- a/recipes/R/Retail - GradientBoosting/Dockerfile
+++ b/recipes/R/Retail - GradientBoosting/Dockerfile
@@ -1,3 +1,20 @@
+#####################################################################
+# ADOBE CONFIDENTIAL
+# ___________________
+#
+#  Copyright 2019 Adobe
+#  All Rights Reserved.
+#
+# NOTICE:  All information contained herein is, and remains
+# the property of Adobe and its suppliers, if any. The intellectual
+# and technical concepts contained herein are proprietary to Adobe
+# and its suppliers and are protected by all applicable intellectual
+# property laws, including trade secret and copyright laws.
+# Dissemination of this information or reproduction of this material
+# is strictly forbidden unless prior written permission is obtained
+# from Adobe.
+#####################################################################
+
 FROM adobe/acp-dsw-ml-runtime-r:0.15.0
 
 RUN install2.r gbm

--- a/recipes/R/Retail - GradientBoosting/Dockerfile
+++ b/recipes/R/Retail - GradientBoosting/Dockerfile
@@ -1,8 +1,9 @@
-FROM adobe/acp-dsw-ml-runtime-r:0.13.1
+FROM adobe/acp-dsw-ml-runtime-r:0.15.0
 
 RUN install2.r gbm
 RUN install2.r lubridate
 RUN install2.r tidyverse
+RUN install2.r evaluators.r.tar.gz
 
 
 WORKDIR /root/sample/code

--- a/recipes/R/Retail - GradientBoosting/R/applicationEvaluator.R
+++ b/recipes/R/Retail - GradientBoosting/R/applicationEvaluator.R
@@ -71,9 +71,9 @@ applicationEvaluator <- setRefClass("applicationEvaluator",
                weeklySalesDiff = (weeklySales - weeklySalesLag) / weeklySalesLag) %>%
         drop_na() %>%
         filter(if(!is.null(timeframe)) {
-          date >= as.Date(Sys.time()-as.numeric(timeframe)*60) & date <= as.Date(Sys.time())
+        date >= as.Date(Sys.time()-as.numeric(timeframe)*60) & date <= as.Date(Sys.time())
         } else {
-          date >= "2012-02-03"
+        date >= "2012-02-03"
         }) %>%
         select(-date)
 

--- a/recipes/R/Retail - GradientBoosting/R/applicationEvaluator.R
+++ b/recipes/R/Retail - GradientBoosting/R/applicationEvaluator.R
@@ -15,7 +15,7 @@
 
 
 # Set up abstractEvaluator
-abstractEvaluator <- ml.runtime.r::abstractEvaluator
+abstractEvaluator <- evaluators.r::regressionEvaluator
 
 #' applicationEvaluator
 #'
@@ -23,26 +23,31 @@ abstractEvaluator <- ml.runtime.r::abstractEvaluator
 #' @export applicationEvaluator
 #' @exportClass applicationEvaluator
 applicationEvaluator <- setRefClass("applicationEvaluator",
-  contains = "abstractEvaluator",
+  contains = "regressionEvaluator",
   methods = list(
-    evaluate = function(configurationJSON) {
-      print("Running Evaluation Function.")
-      
+    split = function(configurationJSON) {
+      print("Running Split Function.")
+
+      #########################################
+      # Load Libraries
+      #########################################
+      library(gbm)
+      library(lubridate)
+      library(tidyverse)
       #########################################
       # Load Data
       #########################################
       reticulate::use_python("/usr/bin/python3.6")
       data_access_sdk_python <- reticulate::import("data_access_sdk_python")
-      
+
       reader <- data_access_sdk_python$reader$DataSetReader(client_id = configurationJSON$ML_FRAMEWORK_IMS_USER_CLIENT_ID,
                                                             user_token = configurationJSON$ML_FRAMEWORK_IMS_TOKEN,
                                                             service_token = configurationJSON$ML_FRAMEWORK_IMS_ML_TOKEN)
-      
+
       df <- reader$load(configurationJSON$trainingDataSetId, configurationJSON$ML_FRAMEWORK_IMS_ORG_ID)
       df <- as_tibble(df)
-      
-      
-      #########################################
+
+      #######################################
       # Data Preparation/Feature Engineering
       #########################################
       timeframe <- configurationJSON$timeframe
@@ -55,42 +60,40 @@ applicationEvaluator <- setRefClass("applicationEvaluator",
         }
       }
       df <- df %>%
-        mutate(store = as.numeric(store)) %>% 
+        mutate(store = as.numeric(store)) %>%
         mutate(date = mdy(date), week = week(date), year = year(date)) %>%
         mutate(new = 1) %>%
         spread(storeType, new, fill = 0) %>%
         mutate(isHoliday = as.integer(isHoliday)) %>%
         mutate(weeklySalesAhead = lead(weeklySales, 45),
                weeklySalesLag = lag(weeklySales, 45),
+               weeklySalesScaled = lead(weeklySalesAhead, 45),
                weeklySalesDiff = (weeklySales - weeklySalesLag) / weeklySalesLag) %>%
         drop_na() %>%
         filter(if(!is.null(timeframe)) {
-        date >= as.Date(Sys.time()-as.numeric(timeframe)*60) & date <= as.Date(Sys.time())
+          date >= as.Date(Sys.time()-as.numeric(timeframe)*60) & date <= as.Date(Sys.time())
         } else {
-        date >= "2012-02-03"  
+          date >= "2012-02-03"
         }) %>%
         select(-date)
-      
-      
+
       #########################################
-      # Retrieve saved model and evaluate
+      # Split Data
       #########################################
-      retrieved_model <- readRDS("model.rds")
-      pred <- predict(retrieved_model, df, n.trees = 100)
-      
-      mape <- mean(abs((df$weeklySalesAhead - pred) / df$weeklySalesAhead))
-      mae <- mean(abs(df$weeklySalesAhead - pred))
-      rmse <- sqrt(mean((df$weeklySalesAhead - pred)^2))
-      
-      insight1 <- list(name = "MAPE", valueType = "number",
-                       value = round(mape, 3))
-      insight2 <- list(name = "MAE", valueType = "number",
-                       value = round(mae, 3))
-      insight3 <- list(name = "RMSE", valueType = "number",
-                       value = round(rmse, 3))
-      metrics <- list(insight1, insight2, insight3)
-      
-      return(metrics)
+      seed = 101
+      if(!is.null(configurationJSON$evaluation.seed)){
+        seed = as.numeric(configurationJSON$evaluation.seed)
+      }
+      trainRatio = 0.8
+      if(!is.null(configurationJSON$evaluation.trainRatio)){
+        train_ratio = as.numeric(configurationJSON$evaluation.trainRatio)
+      }
+      set.seed(seed)
+      sample <- sample.int(n = nrow(df), size = floor(trainRatio*nrow(df)), replace = F)
+      train_df <- df[sample, ]
+      test_df  <- df[-sample, ]
+
+      return (list(train = train_df, test = test_df))
     }
   )
 )

--- a/recipes/R/Retail - GradientBoosting/R/applicationEvaluator.R
+++ b/recipes/R/Retail - GradientBoosting/R/applicationEvaluator.R
@@ -86,7 +86,7 @@ applicationEvaluator <- setRefClass("applicationEvaluator",
       }
       trainRatio = 0.8
       if(!is.null(configurationJSON$evaluation.trainRatio)){
-        train_ratio = as.numeric(configurationJSON$evaluation.trainRatio)
+        trainRatio = as.numeric(configurationJSON$evaluation.trainRatio)
       }
       set.seed(seed)
       sample <- sample.int(n = nrow(df), size = floor(trainRatio*nrow(df)), replace = F)

--- a/recipes/R/Retail - GradientBoosting/R/applicationScorer.R
+++ b/recipes/R/Retail - GradientBoosting/R/applicationScorer.R
@@ -75,8 +75,9 @@ applicationScorer <- setRefClass("applicationScorer",
         spread(storeType, new, fill = 0) %>%
         mutate(isHoliday = as.integer(isHoliday)) %>%
         mutate(weeklySalesAhead = lead(weeklySales, 45),
-           weeklySalesLag = lag(weeklySales, 45),
-           weeklySalesDiff = (weeklySales - weeklySalesLag) / weeklySalesLag) %>%
+               weeklySalesLag = lag(weeklySales, 45),
+               weeklySalesScaled = lead(weeklySalesAhead, 45),
+               weeklySalesDiff = (weeklySales - weeklySalesLag) / weeklySalesLag) %>%
         drop_na() 
       
       test_df <- df %>%
@@ -105,7 +106,7 @@ applicationScorer <- setRefClass("applicationScorer",
         mutate(prediction = pred,
                store = as.integer(store),
                date = as.character(date))
-      
+
       
       #########################################
       # Write Results

--- a/recipes/R/Retail - GradientBoosting/retail.config.json
+++ b/recipes/R/Retail - GradientBoosting/retail.config.json
@@ -31,6 +31,10 @@
         "value": "0.7"
       },
       {
+        "key": "evaluation.seed",
+        "value": "100"
+      },
+      {
         "key": "algorithm",
         "value": "Regression"
       },

--- a/recipes/R/Retail - GradientBoosting/retail.config.json
+++ b/recipes/R/Retail - GradientBoosting/retail.config.json
@@ -15,6 +15,26 @@
         "value": "3"
       },
       {
+        "key": "evaluation.metrics",
+        "value": "MAPE,MAE,RMSE,MASE"
+      },
+      {
+        "key": "evaluation.labelColumn",
+        "value": "weeklySalesAhead"
+      },
+      {
+        "key": "evaluation.scalingColumn",
+        "value": "weeklySalesScaled"
+      },
+      {
+        "key": "evaluation.trainRatio",
+        "value": "0.7"
+      },
+      {
+        "key": "algorithm",
+        "value": "Regression"
+      },
+      {
         "key": "ACP_DSW_INPUT_FEATURES",
         "value": "date,store,storeType,storeSize,temperature,regionalFuelPrice,markdown,cpi,unemployment,isHoliday"
       },


### PR DESCRIPTION
Since we now have default evaluators in ml-runtime level (classification and regression), sample code need to be updated according that changes.
We now have first call to split method in sample project, then we use train data for training, and then testing data for evaluation.
Evaluate method is now moved to default evaluators.
Loading data is removed from applicationTrainer, since we need to load data only in split method in evaluator class.
Fully tested.