### PR TITLE
PLATML 5212 - removing hardcoded catalog and ingestion urls

### DIFF
--- a/recipes/R/Retail - GradientBoosting/R/applicationScorer.R
+++ b/recipes/R/Retail - GradientBoosting/R/applicationScorer.R
@@ -118,14 +118,9 @@ applicationScorer <- setRefClass("applicationScorer",
       #########################################
       reticulate::use_python("/usr/bin/python3.6")
       data_access_sdk_python <- reticulate::import("data_access_sdk_python")
-      
-      catalog_url <- "https://platform.adobe.io/data/foundation/catalog"
-      ingestion_url <- "https://platform.adobe.io/data/foundation/import"
-      
+
       print("Set up writer")
-      writer <- data_access_sdk_python$writer$DataSetWriter(catalog_url = catalog_url,
-                                                            ingestion_url = ingestion_url,
-                                                            client_id = configurationJSON$ML_FRAMEWORK_IMS_USER_CLIENT_ID,
+      writer <- data_access_sdk_python$writer$DataSetWriter(client_id = configurationJSON$ML_FRAMEWORK_IMS_USER_CLIENT_ID,
                                                             user_token = configurationJSON$ML_FRAMEWORK_IMS_TOKEN,
                                                             service_token = configurationJSON$ML_FRAMEWORK_IMS_ML_TOKEN)
       print("Writer configured")


### PR DESCRIPTION
Currently `catalog_url` and `ingestion_url` are hardcoded in applicationScorer.R 
(both are pointing to PROD).
I need to run sample R as IT test as part of my CI/CD work for ml-runtime-r, and it's need to run on INT env.
In order to achieve that, I removed them from the code.
Now, sample is working for both PROD and INT environment. 
Fully tested on both envs.

Sample Python is already running scoring jobs without passing that values to DataSetWritter : 
https://github.com/adobe/experience-platform-dsw-reference/blob/c4ceb414cc9e1931a233d5f2ca27b910349b414f/recipes/python/retail/retail/datasaver.py#L25

I believe that both urls are resolved in data-access-sdk-python project.

**If there is a reason to leave this values hardcoded, please comment.**

UI PROD url for tested recipe without that values : https://platform.adobe.com/ml/models/96ef401f-0055-438d-b113-3a204132e1d1?limit=50&page=1&sortDescending=1&sortField=created

cc : @tatsuyawi  @paulhsiung 
