### PR TITLE
PLATML-4868 Include sandboxIds with latest python runtime version

### DIFF
--- a/recipes/python/retail/Dockerfile
+++ b/recipes/python/retail/Dockerfile
@@ -15,7 +15,7 @@
 # from Adobe.
 #####################################################################
 
-FROM adobe/acp-dsw-ml-runtime-python:0.27.0
+FROM adobe/acp-dsw-ml-runtime-python:0.31.4
 
 #INSTALL modules needed by application
 RUN /usr/bin/python3.5 -m pip install -U numpy==1.16.2


### PR DESCRIPTION
Update to use latest pyspark runtime version.
