### PR TITLE
PLAT-97089 updating authoring sdk and ml-runtime

### DIFF
--- a/recipes/scala/Dockerfile
+++ b/recipes/scala/Dockerfile
@@ -14,6 +14,6 @@
 # is strictly forbidden unless prior written permission is obtained
 # from Adobe.
 #####################################################################
-FROM adobe/acp-dsw-ml-runtime:2.1.0
+FROM adobe/acp-dsw-ml-runtime:2.1.1
 
 COPY target/ml-retail-sample-spark-*-jar-with-dependencies.jar /application.jar

--- a/recipes/scala/pom.xml
+++ b/recipes/scala/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<encoding>UTF-8</encoding>
 		<scala.compat.version>2.11</scala.compat.version>
-		<spark.version>2.1.0</spark.version>
+		<spark.version>2.4.5</spark.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>com.adobe.platform.ml</groupId>
 			<artifactId>authoring-sdk_2.11</artifactId>
-			<version>2.1.0</version>
+			<version>2.1.1</version>
 			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
updating ml-runtime to include DBR 6.4.x - https://git.corp.adobe.com/ml/ml-runtime/releases/tag/2.1.1
model-authoring-sdk 2.1.1 released here: https://git.corp.adobe.com/ml/model-authoring-sdk/releases/tag/2.1.1

Also, pushed to Nexus Sonatype Central repo-
<img width="1195" alt="Screen Shot 2021-05-25 at 3 11 59 PM" src="https://user-images.githubusercontent.com/2782063/119575272-a1e19d00-bd6b-11eb-8047-40de6135cc50.png">

