### PR TITLE
PLAT-98168  Updating QS SDK

### DIFF
--- a/recipes/scala/Dockerfile
+++ b/recipes/scala/Dockerfile
@@ -14,6 +14,6 @@
 # is strictly forbidden unless prior written permission is obtained
 # from Adobe.
 #####################################################################
-FROM adobe/acp-dsw-ml-runtime:2.1.0
+FROM adobe/acp-dsw-ml-runtime:2.2.0
 
 COPY target/ml-retail-sample-spark-*-jar-with-dependencies.jar /application.jar

--- a/recipes/scala/pom.xml
+++ b/recipes/scala/pom.xml
@@ -13,7 +13,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<encoding>UTF-8</encoding>
 		<scala.compat.version>2.11</scala.compat.version>
-		<spark.version>2.1.0</spark.version>
+		<spark.version>2.4.3</spark.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>com.adobe.platform.ml</groupId>
 			<artifactId>authoring-sdk_2.11</artifactId>
-			<version>2.1.0</version>
+			<version>2.2.0</version>
 			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
released ml-runtime 2.2.0 here: https://hub.docker.com/repository/docker/adobe/acp-dsw-ml-runtime/tags?page=1&ordering=last_updated

authoring sdk 2.2.0 released with PQS SDK 2.03:
<img width="1191" alt="Screen Shot 2021-06-21 at 4 03 15 PM" src="https://user-images.githubusercontent.com/2782063/122838118-3d522900-d2aa-11eb-89ce-b3bc3369e2f9.png">
